### PR TITLE
Fixed OP + virtual method do_ex for external EX handlers

### DIFF
--- a/prog/gcd.txt
+++ b/prog/gcd.txt
@@ -2,11 +2,11 @@ R2 PPO # write 12 to R2
 R3 NOP # write -8 to R3
 RR OPN # copy R2 to R1 <─────────────┐
 SK ONN # skip if R1>=0               │ ┌─────────────────────────────┐
-OP NOP # R1 = -R1                    │ │ // This program computes    │
+OP PON # R1 = -R1                    │ │ // This program computes    │
 RR ONP # copy R1 to R2               │ │ // the greatest common      │
 RR OPO # copy R3 to R1               │ │ // divisor between R2       │
 SK ONP # skip if R1<=0               │ │ // and R3. The result is    │
-OP NOP # R1 = -R1                    │ │ // stored in R2.            │
+OP PON # R1 = -R1                    │ │ // stored in R2.            │
 RR ONO # copy R1 to R3               │ │ //                          │
 R1 NNO #                             │ │ // A C++ world equivalent   │
 RR NNN # choose segment NNO          │ │ // is listed below:         │

--- a/triador.cpp
+++ b/triador.cpp
@@ -23,6 +23,8 @@ Triador::Triador() {
     for (int &r : R)
         r = std::rand()%27 - 13;
     C = std::rand()%2 - 1;
+
+    fHalt = false;
 }
 
 void Triador::assert_memory_state() {
@@ -122,6 +124,7 @@ void Triador::cycle() {
 
     switch (opcode) {
         case -4: { // EX: halt and catch fire
+                     if (!doEX(arg)) fHalt = true;
                      return;
                  } break;
         case -3: { // JP: jump instruction
@@ -184,9 +187,9 @@ void Triador::cycle() {
     PC++; // advance the program counter
 }
 
-void Triador::run() {
+void Triador::run(bool verbose) {
     assert_memory_state();
-    display_memory_state();
+    if (verbose) display_memory_state();
     while (1) {
         cycle();
         assert_memory_state();
@@ -195,8 +198,7 @@ void Triador::run() {
             std::cerr << "Warning: PC points outside the program, halting Triador" << std::endl;
             break;
         }
-        display_memory_state();
-        if (program[PC+364].first == -4) break; // halt and catch fire
+        if (verbose) display_memory_state();
+        if (fHalt) break; // halt and catch fire
     }
 }
-

--- a/triador.cpp
+++ b/triador.cpp
@@ -123,7 +123,7 @@ void Triador::cycle() {
     assert(abs(opcode)<=4 && abs(arg)<=13);
 
     switch (opcode) {
-        case -4: { // EX: halt and catch fire
+        case -4: { // EX: halt and catch fire if not processed
                      if (!doEX(arg)) fHalt = true;
                      return;
                  } break;

--- a/triador.cpp
+++ b/triador.cpp
@@ -154,7 +154,7 @@ void Triador::cycle() {
                      binary_to_ternary(R[0], ttt_mem);
                      binary_to_ternary(arg,  ttt_arg);
                      for (int i=0; i<3; i++)
-                         ttt_res[i] = ttt_arg[ttt_mem[i]+1];
+                         ttt_res[i] = ttt_arg[1-ttt_mem[i]];
                      R[0] = ttt_res[0] + 3*ttt_res[1] + 9*ttt_res[2];
                  } break;
         case 0: { // RR: copying between registers

--- a/triador.cpp
+++ b/triador.cpp
@@ -124,7 +124,7 @@ void Triador::cycle() {
 
     switch (opcode) {
         case -4: { // EX: halt and catch fire if not processed
-                     if (!doEX(arg)) fHalt = true;
+                     if (!do_ex(arg)) fHalt = true;
                      return;
                  } break;
         case -3: { // JP: jump instruction

--- a/triador.h
+++ b/triador.h
@@ -11,12 +11,14 @@ struct Triador {
     void assert_memory_state();              // check all the admissible ranges
     void load_program(const char *filename); // fill program array
     void cycle();                            // execute one instruction
-    void run();                              // call cycle() in a loop
+    void run(bool verbose = true);           // call cycle() in a loop
+    virtual bool doEX(int){return false;}    // optional EX executor
 
     std::array<int, 13> R; // 13 registers, valid range for each one -13..+13
     int  C;                // borrow-carry flag, valid values -1,0,+1
     int PC;                // program counter, valid range -364..+364
     std::vector<std::pair<int, int> > program; // read-only program memory, vector of (opcode,argument) pairs
+    bool fHalt;            // half flag
 };
 
 #endif //__TRIADOR_H__

--- a/triador.h
+++ b/triador.h
@@ -12,7 +12,7 @@ struct Triador {
     void load_program(const char *filename); // fill program array
     void cycle();                            // execute one instruction
     void run(bool verbose = true);           // call cycle() in a loop
-    virtual bool doEX(int){return false;}    // optional EX executor
+    virtual bool do_ex(int){return false;}    // optional EX executor
 
     std::array<int, 13> R; // 13 registers, valid range for each one -13..+13
     int  C;                // borrow-carry flag, valid values -1,0,+1


### PR DESCRIPTION
Fix to make OP functionality consistent with historical works (so OP NOP will do nothing and OP PON will do inversion)